### PR TITLE
Prevent bs-button-focusout event to be triggered before clicking dropdown item

### DIFF
--- a/components/dropdown/bs-dropdown-item-mixin.js
+++ b/components/dropdown/bs-dropdown-item-mixin.js
@@ -19,7 +19,7 @@ const BsDropdownItemMixin = (superClass) => class extends superClass {
     firstUpdated() {
         const buttonElement = this._retrieveButtonElement();
         this._applyButtonActivateState(buttonElement);
-        buttonElement.addEventListener('click', event => this._handleButtonClick(event));
+        buttonElement.addEventListener('mousedown', event => this._handleButtonClick(event));
     }
     
     _retrieveButtonElement() {
@@ -48,8 +48,6 @@ const BsDropdownItemMixin = (superClass) => class extends superClass {
     }
     
     _handleButtonClick(event) {
-        
-        event.preventDefault();
         
         if(!this.disabled) {
             


### PR DESCRIPTION
If you create an input-group with bs-dropdown-item-button, you can't add event listeners to the dropdown buttons, this should be fixed with this commit.

Script to test:

`

    const inputGroup = document.createElement('bs-input-group')
    inputGroup.name="input-group"
    const inputELem = document.createElement('bs-form-input')
    const inputAppendPart = document.createElement('bs-input-group-append')
    const inputDropdown = document.createElement('bs-dropdown')
    const inputDropdownButton = document.createElement('bs-button')
    inputDropdownButton.setAttribute('dropdown-toggle', '')
    inputDropdownButton.setAttribute('outline-secondary', '')
    const inputDropdownMenu = document.createElement('bs-dropdown-menu')
    inputDropdownMenu.setAttribute('down', '')
    inputDropdownMenu.setAttribute('x-placement','bottom-start')
    const inputDropdownMenuItem = document.createElement('bs-dropdown-item-button')
    inputDropdownMenuItem.setAttribute('title', "Action")
    inputDropdownMenuItem.setAttribute('index', "0")
    const inputDropdownMenuItem2 = document.createElement('bs-dropdown-item-button')
    inputDropdownMenuItem2.setAttribute('title', "Another action")
    inputDropdownMenuItem2.setAttribute('index', "1")
    
    inputGroup.appendChild(inputELem)
    inputGroup.appendChild(inputAppendPart)

    inputAppendPart.appendChild(inputDropdown)

    inputDropdown.appendChild(inputDropdownButton)
    inputDropdown.appendChild(inputDropdownMenu)

    inputDropdownMenu.appendChild(inputDropdownMenuItem)
    inputDropdownMenu.appendChild(inputDropdownMenuItem2)

    inputDropdownMenuItem.addEventListener('bs-dropdown-item-click', (event)=>console.log("Click action with index 0"))
document.body.appendChild(inputGroup)
`

