### PR TITLE
feat: allow any element to become the dropdown-toggle

### DIFF
--- a/packages/components/dropdown/src/bs-dropdown.js
+++ b/packages/components/dropdown/src/bs-dropdown.js
@@ -138,8 +138,7 @@ export class BsDropdown extends LitElement {
             
             const slotItem = slotNodes[index];
             
-            if (this._isDropdownButtonElement(slotItem) && 
-                this._isDropdownButtonToggle(slotItem)) {
+            if (this._isDropdownButtonToggle(slotItem)) {
                 
                 return slotItem;
             }
@@ -159,19 +158,13 @@ export class BsDropdown extends LitElement {
     }
     
     _isDropdownButtonToggle(element) {
-        return element.hasAttribute('dropdown-toggle');
+        return element.nodeType === Node.ELEMENT_NODE &&
+            element.hasAttribute('dropdown-toggle');
     }
     
     _isDropdownMenuElement(element) {
         return element.nodeType === Node.ELEMENT_NODE 
                 && (element.localName === 'bs-dropdown-menu');
-    }
-    
-    _isDropdownButtonElement(element) {
-        return element.nodeType === Node.ELEMENT_NODE && 
-                (element.localName === 'bs-button' || 
-                 element.localName === 'bs-link-button' || 
-                 element.localName === 'bs-input-button');
     }
     
     _isParentElementNavItem() {


### PR DESCRIPTION
This simple change relaxes the criteria to choose element which toggle the dropdown.

By removing the limitation to only `bs-button`, `bs-link-button` and `bs-input-button` any custom element can be used as long as it behaves like one.

Turns out that the `BsButtonMixin` does exactly that and by applying it to my element I was able to use it as the dropdown toggle

```js
@customElement('canvas-button')
export class CanvasButton extends BsButtonMixin(CanvasShellBase(LitElement)) {

  @property({ type: Boolean, reflect: true, attribute: 'dropdown-toggle' })
  public dropdownToggle = false
}
```

The only other requirement is for the element to render a `button`, `input` or `a` which will be picked to wire up events.

Note that for some reason I needed to explicitly add the `dropdownToggle` property because the one from the mixing somehow does not pick up the `[dropdown-toggle]` attribute. Works fine when set with property like `.dropdownToggle="${true}"` though 🤷‍♂ .