### PR TITLE
fix: do not change backdrop opacity when it should stay visible

### DIFF
--- a/packages/components/modal/src/bs-modal.js
+++ b/packages/components/modal/src/bs-modal.js
@@ -65,9 +65,6 @@ export class BsModal extends LitElement {
         const modalBackdrop = this.shadowRoot.querySelector('.modal-backdrop');
         modalBackdrop.addEventListener('click', () => this._handleBackdropClickEvent());
         modalBackdrop.addEventListener('transitionend', () => this._handleModalBackdropTransitionEnd());
-
-        const modalDialogElement = this.shadowRoot.querySelector('.modal-dialog');
-        modalDialogElement.addEventListener('transitionend', () => this._handleModalDialogTransitionEnd());
     }
 
     _handleDismissEvent() {


### PR DESCRIPTION
Appears to fix #20 while keeping the correct backdrop behavior

Unfortunately I failed at the test. I don't know how to programatically focus an input to cause the transition.