### PR TITLE
Don't instantiate popper if no `x-placement` value is provided

### DIFF
--- a/packages/components/dropdown/src/bs-dropdown.js
+++ b/packages/components/dropdown/src/bs-dropdown.js
@@ -67,6 +67,9 @@ export class BsDropdown extends LitElement {
     _configurePopper(dropdownButtonElement, dropdownMenuElement) {
         
         const dropdDownMenuPlacement = dropdownMenuElement.getAttribute('x-placement');
+        if (!dropdDownMenuPlacement) {
+            return;
+        }
         const referenceElement = this._findReferenceElement(dropdownButtonElement);
 
         const config = this._createPopperConfig(dropdDownMenuPlacement);


### PR DESCRIPTION
Hi there,

thanks for creating this library, I plan to use it for [converse.js](https://github.com/conversejs/converse.js) which I'm currently updating to use web components.

I'm trying to place a dropdown menu to the left of a hamburger menu and noticed that no matter what `x-placement` value I provide, the menu goes out of the view port.

When I don't provide an `x-placement` value, so that Popper doesn't get instantiated, then the menu displays correctly, however without this fix Popper throws an ugly error due to `placement` not being defined.